### PR TITLE
fixed the login issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,33 @@
+# --- Python Virtual Environment ---
+# Ignore the virtual environment folder to avoid committing packages
+venv/
+.venv/
+env/
+ENV/
+
+# --- Application-Specific Folders ---
+# Ignore folders for user uploads and generated documents
+uploads/
+generated/
+
+# --- Python Cache and Bytecode ---
+# Ignore Python's cache folders and compiled files
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+
+# --- Environment Variables ---
+# Ignore local environment variable files that may contain secrets
+.env
+.flaskenv
+
+# --- Operating System Files ---
+# Ignore common OS-generated files
+.DS_Store
+Thumbs.db
+
+# --- IDE/Editor-Specific Files ---
+# Ignore configuration files from popular editors like VSCode
+.vscode/
+.idea/

--- a/excom_dashboard/routes.py
+++ b/excom_dashboard/routes.py
@@ -44,10 +44,10 @@ def mom_generator():
     role = session.get('role', 'member')
 
     if request.method == 'POST':
-        title = request.form['title']
+        agenda = request.form['agenda']
         date = request.form['date'] or datetime.now().strftime('%B %d, %Y')
         attendees = request.form['attendees']
-        points = request.form['discussion_points']
+        discussion = request.form['discussion']
 
         doc = Document()
         doc.add_heading('Minutes of Meeting', 0)

--- a/generate_users.py
+++ b/generate_users.py
@@ -1,0 +1,30 @@
+import json
+from werkzeug.security import generate_password_hash
+
+users = {
+    "chair": {
+        "password": str(generate_password_hash("ieee123")),
+        "role": "chair"
+    },
+    "secretary": {
+        "password": str(generate_password_hash("sb2024")),
+        "role": "secretary"
+    },
+    "vicechair": {
+        "password": str(generate_password_hash("vssutvc")),
+        "role": "vicechair"
+    },
+    "treasurer": {
+        "password": str(generate_password_hash("bankieee")),
+        "role": "treasurer"
+    },
+    "webmaster": {
+        "password": str(generate_password_hash("ieeedev")),
+        "role": "webmaster"
+    }
+}
+
+with open("users.json", "w") as f:
+    json.dump(users, f, indent=4)
+
+print("users.json created with hashed passwords and roles.")

--- a/users.json
+++ b/users.json
@@ -1,30 +1,22 @@
-import json
-from werkzeug.security import generate_password_hash
-
-users = {
+{
     "chair": {
-        "password": str(generate_password_hash("ieee123")),
+        "password": "scrypt:32768:8:1$QAhk1lEqsfMT8Lut$91d477c46d7c61781ebeb82df06785f70f8e813dbd7efdcf32b472e230b315be36d4ee40af9ba23ef0fdfc71bc8160a98f4367781814cb06c73a376ddd7620ac",
         "role": "chair"
     },
     "secretary": {
-        "password": str(generate_password_hash("sb2024")),
+        "password": "scrypt:32768:8:1$WiW91Gf0rl2mD5fm$d915ea783a72c4e87e1bec2f938b474ee1d79d5fb9a5e8950f8ba39b3b696fc3f99a9a58102ba23f5b72f9c7283e68c53cb9504b45d46e4086ba9fc18ac46b16",
         "role": "secretary"
     },
     "vicechair": {
-        "password": str(generate_password_hash("vssutvc")),
+        "password": "scrypt:32768:8:1$35te2yjOM0AgO8IW$c437ad54e9efff430c98ee781eefde526c8cc3c5c5b7e6ece3791627168c6b3336154d270752812f7756e693b8fe789691fa51f3f9510e005ef2600c34d19d75",
         "role": "vicechair"
     },
     "treasurer": {
-        "password": str(generate_password_hash("bankieee")),
+        "password": "scrypt:32768:8:1$L1qeZbSiFEwUjH5Y$07a817844fe24876a55bf4499ff9e15f6a60625d04d0ba09e883b92f658c38127bf490138fb6471550e33ad93d0e8777adb83cf0fb52b99ac837b726b23f8d06",
         "role": "treasurer"
     },
     "webmaster": {
-        "password": str(generate_password_hash("ieeedev")),
+        "password": "scrypt:32768:8:1$dbXG2dSJXMhXYbKx$2bb31e185b69720f9954d54c75a3d8c8caad2718a6d1f3a600bdb1b27682b32c5385af1d0d82caf6ae4fbca002269f537d111929ea2f07132a6dd515d102c550",
         "role": "webmaster"
     }
 }
-
-with open("users.json", "w") as f:
-    json.dump(users, f, indent=4)
-
-print("users.json created with hashed passwords and roles.")


### PR DESCRIPTION
## Summary by Sourcery

Use a script to generate a secure users.json with hashed passwords, resolve login failures by switching to hashed credentials, standardize form field names in the MOM generator, and ignore generated artifacts via .gitignore.

New Features:
- Introduce a generate_users.py script to create a users.json with hashed passwords and role assignments

Bug Fixes:
- Fix login issue by replacing the static credentials file with hashed passwords generated at runtime

Enhancements:
- Rename form fields in the meeting generator from 'title' to 'agenda' and 'discussion_points' to 'discussion' for clarity

Chores:
- Add a .gitignore to exclude generated files from version control